### PR TITLE
fix(card): prevent Cladogenesis from discarding hand cards when deck is empty

### DIFF
--- a/server/game/cards/12-PV/Cladogenesis.js
+++ b/server/game/cards/12-PV/Cladogenesis.js
@@ -3,15 +3,19 @@ const Card = require('../../Card.js');
 class Cladogenesis extends Card {
     // Play: Each player discards the top card of their deck and reveals their hand. Discard each card that belongs to their discarded card's house. Each player refills their hand as if it were their "draw cards" step.
     setupCardAbilities(ability) {
+        let playerDeckTop, oppDeckTop;
+
         this.play({
             effect: "discard the top card of each player's deck, reveal each player's hand, and discard cards belonging to each player's discarded card's house",
             gameAction: ability.actions.sequential([
-                ability.actions.discardTopOfDeck((context) => ({
-                    target: context.player
-                })),
-                ability.actions.discardTopOfDeck((context) => ({
-                    target: context.player.opponent
-                })),
+                ability.actions.discardTopOfDeck((context) => {
+                    playerDeckTop = context.player.deck[0];
+                    return { target: context.player };
+                }),
+                ability.actions.discardTopOfDeck((context) => {
+                    oppDeckTop = context.player.opponent?.deck[0];
+                    return { target: context.player.opponent };
+                }),
                 ability.actions.reveal((context) => ({
                     target: context.player.hand,
                     chatMessage: true
@@ -20,31 +24,20 @@ class Cladogenesis extends Card {
                     target: context.player.opponent ? context.player.opponent.hand : [],
                     chatMessage: true
                 })),
-                ability.actions.discard((context) => {
-                    let myTop = context.player.discard.length > 0 ? context.player.discard[0] : '';
-                    if (myTop) {
-                        return {
-                            target: context.player.hand.filter((card) =>
-                                myTop.getHouses().some((h) => card.hasHouse(h))
-                            )
-                        };
-                    }
-                    return { target: [] };
-                }),
-                ability.actions.discard((context) => {
-                    let oppTop =
-                        context.player.opponent && context.player.opponent.discard.length > 0
-                            ? context.player.opponent.discard[0]
-                            : undefined;
-                    if (oppTop) {
-                        return {
-                            target: context.player.opponent.hand.filter((card) =>
-                                oppTop.getHouses().some((h) => card.hasHouse(h))
-                            )
-                        };
-                    }
-                    return { target: [] };
-                })
+                ability.actions.discard(() => ({
+                    target: playerDeckTop
+                        ? playerDeckTop.controller.hand.filter((card) =>
+                              playerDeckTop.getHouses().some((h) => card.hasHouse(h))
+                          )
+                        : []
+                })),
+                ability.actions.discard(() => ({
+                    target: oppDeckTop
+                        ? oppDeckTop.controller.hand.filter((card) =>
+                              oppDeckTop.getHouses().some((h) => card.hasHouse(h))
+                          )
+                        : []
+                }))
             ]),
             then: {
                 gameAction: ability.actions.draw((context) => ({

--- a/test/server/cards/12-PV/Cladogenesis.spec.js
+++ b/test/server/cards/12-PV/Cladogenesis.spec.js
@@ -12,11 +12,25 @@ describe('Cladogenesis', function () {
                         'sensor-chief-garcia',
                         'away-team'
                     ],
-                    discard: ['troll', 'cpo-zytar', 'dust-pixie']
+                    discard: [
+                        'troll',
+                        'bumpsy',
+                        'cpo-zytar',
+                        'stealth-mode',
+                        'dust-pixie',
+                        'nepenthe-seed'
+                    ]
                 },
                 player2: {
-                    hand: ['urchin', 'ember-imp', 'dodger', 'dodger', 'dodger'],
-                    discard: ['draining-touch', 'nerve-blast', 'stomp']
+                    hand: ['urchin', 'dodger', 'umbra', 'sneklifter', 'ember-imp', 'censor-philo'],
+                    discard: [
+                        'draining-touch',
+                        'the-terror',
+                        'nerve-blast',
+                        'throwing-stars',
+                        'stomp',
+                        'faust-the-great'
+                    ]
                 }
             });
         });
@@ -41,12 +55,41 @@ describe('Cladogenesis', function () {
             expect(this.player1).isReadyToTakeAction();
         });
 
-        it('should handle empty deck', function () {
+        it('should not discard hand cards when deck is empty even if discard pile has matching house', function () {
             this.player1.player.deck = [];
             this.player2.player.deck = [];
+
+            expect(this.pelf.location).toBe('hand');
+            expect(this.anger.location).toBe('hand');
+            expect(this.huntingWitch.location).toBe('hand');
+            expect(this.sensorChiefGarcia.location).toBe('hand');
+            expect(this.awayTeam.location).toBe('hand');
+
+            expect(this.urchin.location).toBe('hand');
+            expect(this.emberImp.location).toBe('hand');
+            expect(this.dodger.location).toBe('hand');
+            expect(this.umbra.location).toBe('hand');
+            expect(this.sneklifter.location).toBe('hand');
+
+            // No cards should be discarded from hand since there are no cards in deck
             this.player1.play(this.cladogenesis);
+
+            expect(this.pelf.location).toBe('hand');
+            expect(this.anger.location).toBe('hand');
+            expect(this.huntingWitch.location).toBe('hand');
+            expect(this.sensorChiefGarcia.location).toBe('hand');
+            expect(this.awayTeam.location).toBe('hand');
+
+            expect(this.urchin.location).toBe('hand');
+            expect(this.dodger.location).toBe('hand');
+            expect(this.umbra.location).toBe('hand');
+            expect(this.sneklifter.location).toBe('hand');
+            expect(this.emberImp.location).toBe('hand');
+            expect(this.censorPhilo.location).toBe('hand');
+
             expect(this.player1.player.hand.length).toBe(6);
             expect(this.player2.player.hand.length).toBe(6);
+            expect(this.player1).isReadyToTakeAction();
         });
 
         it('should handle empty hand', function () {
@@ -55,6 +98,7 @@ describe('Cladogenesis', function () {
             this.player1.play(this.cladogenesis);
             expect(this.player1.player.hand.length).toBe(6);
             expect(this.player2.player.hand.length).toBe(6);
+            expect(this.player1).isReadyToTakeAction();
         });
     });
 });


### PR DESCRIPTION
Resolves an issue where *Cladogenesis* incorrectly fell back to checking the top card of a player's discard pile to determine which house's cards to discard from hand when their deck was empty.

### Key Changes
- **Pre-capture deck top**: Modified `setupCardAbilities` to capture references to the top card of each player's deck before they are discarded (`playerDeckTop` and `oppDeckTop`).
- **Refined discard logic**: Refactored hand-discarding logic to reference the pre-captured deck cards directly, ensuring no discard happens if the deck was empty, regardless of discard pile contents.
- **Enhanced test assertions**: Expanded and corrected the empty deck test cases in `Cladogenesis.spec.js` to verify no hand cards are discarded when player decks are empty, even if matching house cards are in the discard pile.